### PR TITLE
Fixing url as /api/ prefix must now be used to access API URLs

### DIFF
--- a/check_foreman_puppet_failure.pl
+++ b/check_foreman_puppet_failure.pl
@@ -103,7 +103,7 @@ if($username and $password){
 
 
 #We get all the reports
-my $response = $client->GET("/hosts/$host_fqdn/reports",$headers);
+my $response = $client->GET("/api/hosts/$host_fqdn/reports",$headers);
 my $responseCode=$response->responseCode();
 if ($responseCode != 200 ){
 	printf "Problem with Foreman Server. ReponseCode is $responseCode. Check your server log. Exiting\n";


### PR DESCRIPTION
With following commit, foreman want to use /api prefix for API URLs.

https://github.com/theforeman/foreman/commit/76e5dd41bd575f7e6df7c7422660510216a9b964

Otherwise the script will fail like following.

>  ./check_foreman_puppet_failure.pl -H xxx -F https://xxx -w 3 -c 5 -u xxx -p xxx
> Problem with Foreman Server. ReponseCode is 400. Check your server log. Exiting

From logs,

> DEPRECATION: /api/ prefix must now be used to access API URLs, e.g. xxx/api/hosts/xxx/reports.
> Completed 400 Bad Request in 12ms (Views: 0.2ms | ActiveRecord: 0.0ms)

