### PR TITLE
Telling Nagios to NOT use the embedded Perl interpreter

### DIFF
--- a/check_foreman_puppet_failure.pl
+++ b/check_foreman_puppet_failure.pl
@@ -6,6 +6,8 @@
 #To install it, use cpan :
 #install REST::Client
 #
+# Telling Nagios to NOT use the embedded Perl interpreter (http://nagios.sourceforge.net/docs/3_0/embeddedperl.html)
+# nagios: -epn
 
 use warnings;
 use utf8;


### PR DESCRIPTION
Check causes following error in nagios-3.5.1-1.el6.x86_64.

>>[1421739922.122276] [016.0] [pid=19966] Attempting to run scheduled check of service 'puppetrun' on host 'xx.pythian.com': check options=0, latency=0.122000
>>[1421739922.122343] [016.0] [pid=19966] Checking service 'puppetrun' on host 'xxb.pythian.com'...
>>[1421739922.122505] [016.1] [pid=19966] Check result output will be written to '/var/log/nagios/spool/checkresults/checknwJ6Zp' (fd=8)
>>[1421739922.122633] [016.1] [pid=19966] ** Using Embedded Perl interpreter to run service check...
>>[1421739922.123440] [016.0] [pid=19966] Embedded Perl failed to compile /usr/lib64/nagios/plugins/check_foreman_puppet_failure.pl, compile error **ePN failed to compile /usr/lib64/nagios/plugins/check_foreman_puppet_failure.pl: "Global symbol "$opt_H" requires explicit package name at (eval 1) line 52,

This patch would fix this by telling nagios to not use the embedded Perl interpreter.  Please refer following, 
http://nagios.sourceforge.net/docs/3_0/embeddedperl.html